### PR TITLE
Replace -x with fabs(x) due to odd breaking Linux behavior

### DIFF
--- a/bayesbridge/random/polya_gamma/scipy_ndtr.c
+++ b/bayesbridge/random/polya_gamma/scipy_ndtr.c
@@ -293,7 +293,9 @@ double erf(double x)
     // }
 
     if (x < 0.0) {
-	return -erf(-x);
+    // original implementation used -x instead of fabs(), but led to breaking behavior on some platforms.
+    // see https://github.com/aki-nishimura/bayes-bridge/pull/7 for more info.
+	return -erf(fabs(x));
     }
 
     if (fabs(x) > 1.0)


### PR DESCRIPTION
Within the [erf()](https://github.com/aki-nishimura/bayes-bridge/blob/16036fd7f0dc49681ddf5a7c5ada3c9246d4a798/bayesbridge/random/polya_gamma/scipy_ndtr.c#L286) function, my code was getting hanging on this statement

```
    if (x < 0.0) {
	return -erf(-x);
    }
```
due to `-x` not being successfully passed into the recursive call (i.e. it was still negative). 

Both
```
    double a;
    if (x < 0.0) {
    a = -1.0*x;
	return -erf(a);
    }
```
and
```
    if (x < 0.0) {
	return -erf(fabs(x));
    }
```
work, as did changing the implementation back to the `scipy.special` one.

Also noting that the following _did not_ work.
```
    if (x < 0.0) {
	return -erf(-1.0*x);
    }
```

This PR implements `fabs()` approach to fix the issue. It was chosen after discussion with @aki-nishimura for simplicity and to avoid any potential other issues with doing a -1 multiplication.

This problem occurred in the following environments:
1. Kubuntu 21.04, gcc version Ubuntu 10.3.0-1ubuntu1
2. Mint 20.1, gcc version Ubuntu 9.3.0-17ubuntu1~20.04 (Mint 20.1 is based on Ubuntu 20.04)

It worked fine for me on windows 10 and all OS's pass on Github Actions, where ubuntu-20.04 is currently the latest supported linux version.

Exact root cause of this issue has not been investigated.