### PR TITLE
Change len() statements to .shape[0] for arrays in logistic model

### DIFF
--- a/bayesbridge/model/logistic_model.py
+++ b/bayesbridge/model/logistic_model.py
@@ -11,7 +11,7 @@ class LogisticModel(AbstractModel):
 
         self.check_input_validity(n_success, n_trial, design)
         if n_trial is None:
-            n_trial = np.ones(len(n_success))
+            n_trial = np.ones(n_success.shape[0])
             warn(
                 "The numbers of trials were not specified. The binary "
                 "outcome is assumed."
@@ -28,13 +28,13 @@ class LogisticModel(AbstractModel):
             if np.max(n_success) > 1:
                 raise ValueError(
                     "If not binary, the number of trials must be specified.")
-            if not len(n_success) == design.shape[0]:
+            if not n_success.shape[0] == design.shape[0]:
                 raise ValueError(
                     "Incompatible sizes of the outcome and design matrix."
                 )
             return # No need to check the rest for the default initialization.
 
-        if not len(n_trial) == len(n_success) == design.shape[0]:
+        if not n_trial.shape[0] == n_success.shape[0] == design.shape[0]:
             raise ValueError(
                 "Incompatible sizes of the outcome vectors and design matrix."
             )


### PR DESCRIPTION
`len()` doesn't work with scipy sparse matrices (it raises `TypeError: sparse matrix length is ambiguous; use getnnz() or shape[0]`), so changing to use shape[0]. 

This just  affects the `logistic_model` class for now. I think some of the other models may hit this issue as well, but I don't have a great sense of where they're potentially using sparse matrices or not. I can also just convert every `len()` in the `model/` folder if that's safe to do.