### PR TITLE
[Draft] Second version of cupy support for sparse matrix cg sampling

### DIFF
--- a/bayesbridge/design_matrix/dense_matrix.py
+++ b/bayesbridge/design_matrix/dense_matrix.py
@@ -1,3 +1,5 @@
+from warnings import warn
+
 import numpy as np
 from .abstract_matrix import AbstractDesignMatrix
 
@@ -5,12 +7,15 @@ from .abstract_matrix import AbstractDesignMatrix
 class DenseDesignMatrix(AbstractDesignMatrix):
     
     def __init__(self, X, center_predictor=False, add_intercept=True,
-                 copy_array=False):
+                 copy_array=False, use_cupy=False):
         """
         Params:
         ------
         X : numpy array
         """
+        if use_cupy:
+            warn("cupy not supported for dense matrices, will continue with scipy.")
+            self.use_cupy=False
         if copy_array:
             X = X.copy()
         super().__init__()

--- a/bayesbridge/design_matrix/sparse_matrix.py
+++ b/bayesbridge/design_matrix/sparse_matrix.py
@@ -6,12 +6,16 @@ try:
     from .mkl_matvec import mkl_csr_matvec
 except:
     mkl_csr_matvec = None
-
+try:
+    import cupy as cp
+except (ImportError, ModuleNotFoundError) as e:
+    cp = None
+    cupy_exception = e
 
 class SparseDesignMatrix(AbstractDesignMatrix):
 
     def __init__(self, X, use_mkl=True, center_predictor=False, add_intercept=True,
-                 copy_array=False, dot_format='csr', Tdot_format='csr'):
+                 copy_array=False, dot_format='csr', Tdot_format='csr', use_cupy=False):
         """
         Params:
         ------
@@ -31,15 +35,21 @@ class SparseDesignMatrix(AbstractDesignMatrix):
             warn("Could not load MKL Library. Will use Scipy's 'dot'.")
             use_mkl = False
         self.use_mkl = use_mkl
-
+        self.use_cupy = use_cupy
         self.centered = center_predictor
         if center_predictor:
             self.column_offset = np.squeeze(np.array(X.mean(axis=0)))
         else:
             self.column_offset = np.zeros(X.shape[1])
-
         self.intercept_added = add_intercept
-        self.X_main = X.tocsr()
+
+        if self.use_cupy and (cp is None):
+            raise cupy_exception
+        elif self.use_cupy:
+            self.X_main = cp.sparse.csr_matrix(X)
+            self.column_offset = cp.asarray(self.column_offset)
+        else:
+            self.X_main = X.tocsr()
 
     @property
     def shape(self):
@@ -59,6 +69,7 @@ class SparseDesignMatrix(AbstractDesignMatrix):
         return self.X_main.nnz
 
     def dot(self, v):
+        input_is_cupy = isinstance(v, cp._core.core.ndarray)
 
         if self.memoized:
             if np.all(self.v_prev == v):
@@ -69,8 +80,14 @@ class SparseDesignMatrix(AbstractDesignMatrix):
         if self.intercept_added:
             intercept_effect += v[0]
             v = v[1:]
-        result = intercept_effect + self.main_dot(v)
-        
+
+        if self.use_cupy:
+            result = intercept_effect + self.main_dot(cp.asarray(v))
+            if not input_is_cupy:
+                result = cp.asnumpy(result)
+        else:
+            result = intercept_effect + self.main_dot(v)
+
         if self.memoized:
             self.X_dot_v = result
         self.dot_count += 1
@@ -79,25 +96,52 @@ class SparseDesignMatrix(AbstractDesignMatrix):
 
     def main_dot(self, v):
         """ Multiply by the main effect part of the design matrix. """
+        type_v = type(v)
         X = self.X_main
-        result = mkl_csr_matvec(X, v) if self.use_mkl else X.dot(v)
-        result -= np.inner(self.column_offset, v)
+        if self.use_cupy:
+            result = X.dot(v)
+            result -= cp.inner(self.column_offset, v)
+        elif self.use_mkl:
+            result = mkl_csr_matvec(X, v)
+            result -= np.inner(self.column_offset, v)
+        else:
+            result = X.dot(v)
+            result -= np.inner(self.column_offset, v)
         if self.memoized:
             self.X_dot_v = result
+        assert type_v == type(result)
         return result
 
     def Tdot(self, v):
-        result = self.main_Tdot(v)
-        if self.intercept_added:
-            result = np.concatenate(([np.sum(v)], result))
+        type_v = type(v)
+        input_is_cupy = isinstance(v, cp._core.core.ndarray)
+        if self.use_cupy:
+            v = cp.asarray(v)
+            result = self.main_Tdot(cp.asarray(v))
+            if self.intercept_added:
+                result = cp.concatenate((cp.asarray([cp.sum(v)]), result))
+        else:
+            result = self.main_Tdot(v)
+            if self.intercept_added:
+                result = np.concatenate(([np.sum(v)], result))
         self.Tdot_count += 1
+
+        if self.use_cupy and not input_is_cupy:
+            result = cp.asnumpy(result)
+        assert type_v == type(result)
         return result
 
     def main_Tdot(self, v):
         X = self.X_main
-        result = mkl_csr_matvec(X, v, transpose=True) \
-            if self.use_mkl else X.T.dot(v)
-        result -= np.sum(v) * self.column_offset
+        if self.use_cupy:
+            result = X.T.dot(v)
+            result -= cp.sum(v) * self.column_offset
+        elif self.use_mkl:
+            result = mkl_csr_matvec(X, v, transpose=True)
+            result -= np.sum(v) * self.column_offset
+        else:
+            result = X.T.dot(v)
+            result -= np.sum(v) * self.column_offset
         return result
 
     def compute_fisher_info(self, weight, diag_only=False):

--- a/bayesbridge/design_matrix/sparse_matrix.py
+++ b/bayesbridge/design_matrix/sparse_matrix.py
@@ -96,7 +96,6 @@ class SparseDesignMatrix(AbstractDesignMatrix):
 
     def main_dot(self, v):
         """ Multiply by the main effect part of the design matrix. """
-        type_v = type(v)
         X = self.X_main
         if self.use_cupy:
             result = X.dot(v)
@@ -109,11 +108,9 @@ class SparseDesignMatrix(AbstractDesignMatrix):
             result -= np.inner(self.column_offset, v)
         if self.memoized:
             self.X_dot_v = result
-        assert type_v == type(result)
         return result
 
     def Tdot(self, v):
-        type_v = type(v)
         input_is_cupy = isinstance(v, cp._core.core.ndarray)
         if self.use_cupy:
             v = cp.asarray(v)
@@ -128,7 +125,6 @@ class SparseDesignMatrix(AbstractDesignMatrix):
 
         if self.use_cupy and not input_is_cupy:
             result = cp.asnumpy(result)
-        assert type_v == type(result)
         return result
 
     def main_Tdot(self, v):

--- a/bayesbridge/model/factory.py
+++ b/bayesbridge/model/factory.py
@@ -8,7 +8,7 @@ from ..design_matrix import DenseDesignMatrix, SparseDesignMatrix
 
 def RegressionModel(
         outcome, X, family='linear',
-        add_intercept=None, center_predictor=True
+        add_intercept=None, center_predictor=True, use_cupy=False
     ):
     """ Prepare input data to BayesBridge, with pre-processings as needed.
 
@@ -43,7 +43,7 @@ def RegressionModel(
     is_sparse = sp.sparse.issparse(X)
     DesignMatrix = SparseDesignMatrix if is_sparse else DenseDesignMatrix
     design = DesignMatrix(
-        X, add_intercept=add_intercept, center_predictor=center_predictor
+        X, add_intercept=add_intercept, center_predictor=center_predictor, use_cupy=use_cupy
     )
 
     if family == 'linear':

--- a/bayesbridge/reg_coef_sampler/cg_sampler.py
+++ b/bayesbridge/reg_coef_sampler/cg_sampler.py
@@ -4,6 +4,14 @@ import scipy.sparse
 import scipy.linalg
 from warnings import warn
 
+try:
+    import cupyx.scipy.sparse.linalg
+    import cupyx as cpx
+    import cupy as cp
+except (ImportError, ModuleNotFoundError) as e:
+    cp = None
+    cupy_exception = e
+
 class ConjugateGradientSampler():
 
     def __init__(self, n_coef_wo_shrinkage):
@@ -18,7 +26,6 @@ class ConjugateGradientSampler():
            Sigma^{-1} = X' Omega X + prior_prec_sqrt^2, mu = Sigma z
         where D is assumed to be diagonal. For numerical stability, the code first sample
         from the scaled parameter regress_coef / precond_scale.
-
         Param:
         ------
         D : vector
@@ -30,19 +37,32 @@ class ConjugateGradientSampler():
             without shrinkage. Used only if precond_by == 'prior'.
         precond_by : {'prior', 'diag'}
         """
-
+        if X.use_cupy:
+            beta_init = cp.asarray(beta_init)
+            beta_scaled_sd = cp.asarray(beta_scaled_sd)
+            prior_prec_sqrt = cp.asarray(prior_prec_sqrt)
+            z = cp.asarray(z)
+            cg = cpx.scipy.sparse.linalg.cg
+            linear_operator = cpx.scipy.sparse.linalg.LinearOperator
+        else:
+            cg = sp.sparse.linalg.cg
+            linear_operator = sp.sparse.linalg.LinearOperator
         if seed is not None:
             np.random.seed(seed)
 
         # Define a preconditioned linear operator.
         Phi_precond_op, precond_scale = \
             self.precondition_linear_system(
-                prior_prec_sqrt, omega, X, precond_by, beta_scaled_sd
+                prior_prec_sqrt, omega, X, precond_by, beta_scaled_sd, linear_operator
             )
 
         # Draw a target vector.
-        v = X.Tdot(omega ** (1 / 2) * np.random.randn(X.shape[0])) \
-            + prior_prec_sqrt * np.random.randn(X.shape[1])
+        if X.use_cupy:
+            v = X.Tdot(omega ** (1 / 2) * cp.asarray(np.random.randn(X.shape[0]))) \
+                + prior_prec_sqrt * cp.asarray(np.random.randn(X.shape[1]))
+        else:
+            v = X.Tdot(omega ** (1 / 2) * np.random.randn(X.shape[0])) \
+                + prior_prec_sqrt * np.random.randn(X.shape[1])
         b = precond_scale * (z + v)
 
         # Callback function to count the number of PCG iterations.
@@ -52,7 +72,7 @@ class ConjugateGradientSampler():
         # Run PCG.
         rtol = atol / np.linalg.norm(b)
         beta_scaled_init = beta_init / precond_scale
-        beta_scaled, info = sp.sparse.linalg.cg(
+        beta_scaled, info = cg(
             Phi_precond_op, b, x0=beta_scaled_init, maxiter=maxiter, tol=rtol,
             callback=cg_callback
         )
@@ -67,11 +87,12 @@ class ConjugateGradientSampler():
         beta = precond_scale * beta_scaled
         cg_info['valid_input'] = (info >= 0)
         cg_info['converged'] = (info == 0)
-
+        if X.use_cupy:
+            beta = cp.asnumpy(beta)
         return beta, cg_info
 
     def precondition_linear_system(
-            self, prior_prec_sqrt, omega, X, precond_by, beta_scaled_sd):
+            self, prior_prec_sqrt, omega, X, precond_by, beta_scaled_sd, linear_operator):
 
         # Compute the preconditioners.
         precond_scale = self.choose_preconditioner(
@@ -84,7 +105,7 @@ class ConjugateGradientSampler():
             Phi_x = precond_prior_prec * x \
                     + precond_scale * X.Tdot(omega * X.dot(precond_scale * x))
             return Phi_x
-        Phi_precond_op = sp.sparse.linalg.LinearOperator(
+        Phi_precond_op = linear_operator(
             (X.shape[1], X.shape[1]), matvec=Phi_precond
         )
         return Phi_precond_op, precond_scale
@@ -103,8 +124,8 @@ class ConjugateGradientSampler():
         # Compute the diagonal (sqrt) preconditioner.
 
         if precond_by == 'prior':
-
-            precond_scale = np.ones(len(prior_prec_sqrt))
+            precond_scale = cp.ones(len(prior_prec_sqrt)) if X.use_cupy \
+                else np.ones(len(prior_prec_sqrt))
             precond_scale[self.n_coef_wo_shrinkage:] = \
                 prior_prec_sqrt[self.n_coef_wo_shrinkage:] ** -1
             if self.n_coef_wo_shrinkage > 0:

--- a/bayesbridge/reg_coef_sampler/cg_sampler.py
+++ b/bayesbridge/reg_coef_sampler/cg_sampler.py
@@ -41,7 +41,6 @@ class ConjugateGradientSampler():
             beta_init = cp.asarray(beta_init)
             beta_scaled_sd = cp.asarray(beta_scaled_sd)
             prior_prec_sqrt = cp.asarray(prior_prec_sqrt)
-            z = cp.asarray(z)
             cg = cpx.scipy.sparse.linalg.cg
             linear_operator = cpx.scipy.sparse.linalg.LinearOperator
         else:

--- a/bayesbridge/reg_coef_sampler/reg_coef_sampler.py
+++ b/bayesbridge/reg_coef_sampler/reg_coef_sampler.py
@@ -74,9 +74,7 @@ class SparseRegressionCoefficientSampler():
         if design.use_cupy:
             obs_prec = cp.asarray(obs_prec)
             y = cp.asarray(y)
-            v = design.Tdot(obs_prec * y).get()
-        else:
-            v = design.Tdot(obs_prec * y)
+        v = design.Tdot(obs_prec * y)
         prior_shrunk_scale = self.compute_prior_shrunk_scale(gscale, lscale)
         prior_sd = np.concatenate((
             self.prior_sd_for_unshrunk, prior_shrunk_scale

--- a/bayesbridge/reg_coef_sampler/reg_coef_sampler.py
+++ b/bayesbridge/reg_coef_sampler/reg_coef_sampler.py
@@ -11,7 +11,11 @@ from .hamiltonian_monte_carlo import hmc
 from .hamiltonian_monte_carlo.nuts import NoUTurnSampler
 from .hamiltonian_monte_carlo.stepsize_adapter \
     import HamiltonianBasedStepsizeAdapter
-
+try:
+    import cupy as cp
+except (ImportError, ModuleNotFoundError) as e:
+    cp = None
+    cupy_exception = e
 
 class SparseRegressionCoefficientSampler():
 
@@ -67,8 +71,12 @@ class SparseRegressionCoefficientSampler():
             sampler is used.
         """
         # TODO: Comment on the form of the posterior.
-
-        v = design.Tdot(obs_prec * y)
+        if design.use_cupy:
+            obs_prec = cp.asarray(obs_prec)
+            y = cp.asarray(y)
+            v = design.Tdot(obs_prec * y).get()
+        else:
+            v = design.Tdot(obs_prec * y)
         prior_shrunk_scale = self.compute_prior_shrunk_scale(gscale, lscale)
         prior_sd = np.concatenate((
             self.prior_sd_for_unshrunk, prior_shrunk_scale


### PR DESCRIPTION
Unlike #15, this PR adds the use_cupy flag to the model/matrix, and then has the dot function handle the types of the input vectors case by case. This way cg_sampler can just use the design matrix flags without needing a use_cupy flag. Theres' probably cleaner way to do the logic, but as a prototype it seems to work and is actually faster than #15.